### PR TITLE
Fix/lint issues

### DIFF
--- a/agent/reverseproxy/server.go
+++ b/agent/reverseproxy/server.go
@@ -27,7 +27,7 @@ type Server struct {
 
 func NewServer(
 	conf config.ListenerConfig,
-	metrics *middleware.Metrics,
+	metrics *middleware.LabeledMetrics,
 	logger log.Logger,
 ) *Server {
 	logger = logger.WithSubsystem("proxy.http")

--- a/agent/reverseproxy/server_test.go
+++ b/agent/reverseproxy/server_test.go
@@ -51,7 +51,7 @@ func TestServer_Forward(t *testing.T) {
 		defer upstream.Close()
 
 		registry := prometheus.NewRegistry()
-		metrics := middleware.NewLabeledMetrics(registry, "test")
+		metrics := middleware.NewLabeledMetrics("test")
 		configs := []config.ListenerConfig{
 			{
 				EndpointID: "my-endpoint",
@@ -62,6 +62,7 @@ func TestServer_Forward(t *testing.T) {
 				Addr:       upstream.URL,
 			},
 		}
+		metrics.Register(registry)
 
 		testConfig := func(t *testing.T, cfg config.ListenerConfig) {
 			// Need a real listener to test Server

--- a/agent/reverseproxy/server_test.go
+++ b/agent/reverseproxy/server_test.go
@@ -51,7 +51,7 @@ func TestServer_Forward(t *testing.T) {
 		defer upstream.Close()
 
 		registry := prometheus.NewRegistry()
-		metrics := middleware.NewMetrics("test")
+		metrics := middleware.NewLabeledMetrics(registry, "test")
 		configs := []config.ListenerConfig{
 			{
 				EndpointID: "my-endpoint",
@@ -82,7 +82,6 @@ func TestServer_Forward(t *testing.T) {
 			body := mustGet(t, fmt.Sprintf("http://localhost:%d/foo/bar?a=b", lnPort))
 			assert.Equal(t, "bar", body)
 		}
-		metrics.Register(registry)
 
 		t.Run("fist", func(t *testing.T) {
 			testConfig(t, configs[0])

--- a/cli/agent/command.go
+++ b/cli/agent/command.go
@@ -125,7 +125,7 @@ func runAgent(conf *config.Config, logger log.Logger) error {
 
 	var group rungroup.Group
 
-	agentMetrics := middleware.NewLabeledMetrics(registry, "agent")
+	agentMetrics := middleware.NewLabeledMetrics("agent")
 	for _, listenerConfig := range conf.Listeners {
 		connectCtx, connectCancel := context.WithTimeout(
 			context.Background(),

--- a/cli/agent/command.go
+++ b/cli/agent/command.go
@@ -125,7 +125,7 @@ func runAgent(conf *config.Config, logger log.Logger) error {
 
 	var group rungroup.Group
 
-	agentMetrics := middleware.NewMetrics("agent")
+	agentMetrics := middleware.NewLabeledMetrics(registry, "agent")
 	for _, listenerConfig := range conf.Listeners {
 		connectCtx, connectCancel := context.WithTimeout(
 			context.Background(),
@@ -177,7 +177,6 @@ func runAgent(conf *config.Config, logger log.Logger) error {
 			panic("unsupported protocol: " + listenerConfig.Protocol)
 		}
 	}
-	agentMetrics.Register(registry)
 
 	// Agent server.
 	if conf.Server.Enabled {

--- a/pkg/middleware/metrics.go
+++ b/pkg/middleware/metrics.go
@@ -9,7 +9,54 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type Metrics struct {
+type gaugeOptions struct {
+	RequestsInFlight prometheus.GaugeOpts
+	RequestsTotal    prometheus.CounterOpts
+	RequestLatency   prometheus.HistogramOpts
+	RequestSize      prometheus.HistogramOpts
+	ResponseSize     prometheus.HistogramOpts
+}
+
+func newOptions(subsystem string) gaugeOptions {
+	sizeBuckets := prometheus.ExponentialBuckets(256, 4, 8)
+	return gaugeOptions{
+		RequestsInFlight: prometheus.GaugeOpts{
+			Namespace: "piko",
+			Subsystem: subsystem,
+			Name:      "requests_in_flight",
+			Help:      "Number of requests currently handled by this server.",
+		},
+		RequestsTotal: prometheus.CounterOpts{
+			Namespace: "piko",
+			Subsystem: subsystem,
+			Name:      "requests_total",
+			Help:      "Total requests.",
+		},
+		RequestLatency: prometheus.HistogramOpts{
+			Namespace: "piko",
+			Subsystem: subsystem,
+			Name:      "request_latency_seconds",
+			Help:      "Request latency.",
+			Buckets:   prometheus.DefBuckets,
+		},
+		RequestSize: prometheus.HistogramOpts{
+			Namespace: "piko",
+			Subsystem: subsystem,
+			Name:      "request_size_bytes",
+			Help:      "Request size",
+			Buckets:   sizeBuckets,
+		},
+		ResponseSize: prometheus.HistogramOpts{
+			Namespace: "piko",
+			Subsystem: subsystem,
+			Name:      "response_size_bytes",
+			Help:      "Response size",
+			Buckets:   sizeBuckets,
+		},
+	}
+}
+
+type LabeledMetrics struct {
 	RequestsInFlight *prometheus.GaugeVec
 	RequestsTotal    *prometheus.CounterVec
 	RequestLatency   *prometheus.HistogramVec
@@ -17,68 +64,95 @@ type Metrics struct {
 	ResponseSize     *prometheus.HistogramVec
 }
 
-func NewMetrics(subsystem string) *Metrics {
-	sizeBuckets := prometheus.ExponentialBuckets(256, 4, 8)
-	return &Metrics{
-		RequestsInFlight: prometheus.NewGaugeVec(
-			prometheus.GaugeOpts{
-				Namespace: "piko",
-				Subsystem: subsystem,
-				Name:      "requests_in_flight",
-				Help:      "Number of requests currently handled by this server.",
-			},
-			[]string{"endpoint"},
-		),
-		RequestsTotal: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Namespace: "piko",
-				Subsystem: subsystem,
-				Name:      "requests_total",
-				Help:      "Total requests.",
-			},
-			[]string{"endpoint", "status", "method"},
-		),
-		RequestLatency: prometheus.NewHistogramVec(
-			prometheus.HistogramOpts{
-				Namespace: "piko",
-				Subsystem: subsystem,
-				Name:      "request_latency_seconds",
-				Help:      "Request latency.",
-				Buckets:   prometheus.DefBuckets,
-			},
-			[]string{"endpoint", "status", "method"},
-		),
-		RequestSize: prometheus.NewHistogramVec(
-			prometheus.HistogramOpts{
-				Namespace: "piko",
-				Subsystem: subsystem,
-				Name:      "request_size_bytes",
-				Help:      "Request size",
-				Buckets:   sizeBuckets,
-			},
-			[]string{"endpoint"},
-		),
-		ResponseSize: prometheus.NewHistogramVec(
-			prometheus.HistogramOpts{
-				Namespace: "piko",
-				Subsystem: subsystem,
-				Name:      "response_size_bytes",
-				Help:      "Response size",
-				Buckets:   sizeBuckets,
-			},
-			[]string{"endpoint"},
-		),
+type Metrics struct {
+	RequestsInFlight prometheus.Gauge
+	RequestsTotal    *prometheus.CounterVec
+	RequestLatency   prometheus.ObserverVec
+	RequestSize      prometheus.Observer
+	ResponseSize     prometheus.Observer
+}
+
+func NewLabeledMetrics(registry *prometheus.Registry, subsystem string) *LabeledMetrics {
+	if registry == nil {
+		return nil
+	}
+	opts := newOptions(subsystem)
+	requestsInFlight := prometheus.NewGaugeVec(
+		opts.RequestsInFlight,
+		[]string{"endpoint"},
+	)
+	requestsTotal := prometheus.NewCounterVec(
+		opts.RequestsTotal,
+		[]string{"endpoint", "status", "method"},
+	)
+	requestLatency := prometheus.NewHistogramVec(
+		opts.RequestLatency,
+		[]string{"endpoint", "status", "method"},
+	)
+	requestSize := prometheus.NewHistogramVec(opts.RequestSize, []string{"endpoint"})
+	responseSize := prometheus.NewHistogramVec(opts.ResponseSize, []string{"endpoint"})
+	registry.MustRegister(
+		requestsInFlight,
+		requestsTotal,
+		requestLatency,
+		requestSize,
+		responseSize,
+	)
+	return &LabeledMetrics{
+		RequestsInFlight: requestsInFlight,
+		RequestsTotal:    requestsTotal,
+		RequestLatency:   requestLatency,
+		RequestSize:      requestSize,
+		ResponseSize:     responseSize,
 	}
 }
 
-// Handler collects metric for a  particular endpointID (which might be empty)
-func (m *Metrics) Handler(endpointID string) gin.HandlerFunc {
+func (lm *LabeledMetrics) Handler(endpointID string) gin.HandlerFunc {
+	metrics := &Metrics{
+		RequestsInFlight: lm.RequestsInFlight.WithLabelValues(endpointID),
+		RequestsTotal:    lm.RequestsTotal.MustCurryWith(prometheus.Labels{"endpoint": endpointID}),
+		RequestLatency:   lm.RequestLatency.MustCurryWith(prometheus.Labels{"endpoint": endpointID}),
+		RequestSize:      lm.RequestSize.WithLabelValues(endpointID),
+		ResponseSize:     lm.ResponseSize.WithLabelValues(endpointID),
+	}
+	return metrics.Handler()
+}
+
+func NewMetrics(registry *prometheus.Registry, subsystem string) *Metrics {
+	if registry == nil {
+		return nil
+	}
+	opts := newOptions(subsystem)
+	requestsInFlight := prometheus.NewGauge(opts.RequestsInFlight)
+	requestsTotal := prometheus.NewCounterVec(opts.RequestsTotal,
+		[]string{"status", "method"},
+	)
+	requestLatency := prometheus.NewHistogramVec(
+		opts.RequestLatency,
+		[]string{"status", "method"},
+	)
+	requestSize := prometheus.NewHistogram(opts.RequestSize)
+	responseSize := prometheus.NewHistogram(opts.ResponseSize)
+	registry.MustRegister(
+		requestsInFlight,
+		requestsTotal,
+		requestLatency,
+		requestSize,
+		responseSize,
+	)
+	return &Metrics{
+		RequestsInFlight: requestsInFlight,
+		RequestsTotal:    requestsTotal,
+		RequestLatency:   requestLatency,
+		RequestSize:      requestSize,
+		ResponseSize:     responseSize,
+	}
+}
+
+func (m *Metrics) Handler() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		requestsInFlight := m.RequestsInFlight.With(prometheus.Labels{
-			"endpoint": endpointID,
-		})
-		requestsInFlight.Inc()
-		defer requestsInFlight.Dec()
+		m.RequestsInFlight.Inc()
+		defer m.RequestsInFlight.Dec()
 
 		start := time.Now()
 
@@ -86,29 +160,17 @@ func (m *Metrics) Handler(endpointID string) gin.HandlerFunc {
 		c.Next()
 
 		m.RequestsTotal.With(prometheus.Labels{
-			"endpoint": endpointID,
-			"status":   strconv.Itoa(c.Writer.Status()),
-			"method":   c.Request.Method,
+			"status": strconv.Itoa(c.Writer.Status()),
+			"method": c.Request.Method,
 		}).Inc()
 		m.RequestLatency.With(prometheus.Labels{
-			"endpoint": endpointID,
-			"status":   strconv.Itoa(c.Writer.Status()),
-			"method":   c.Request.Method,
+			"status": strconv.Itoa(c.Writer.Status()),
+			"method": c.Request.Method,
 		}).Observe(float64(time.Since(start).Milliseconds()) / 1000)
 
-		m.RequestSize.WithLabelValues(endpointID).Observe(float64(computeApproximateRequestSize(c.Request)))
-		m.ResponseSize.WithLabelValues(endpointID).Observe(float64(c.Writer.Size()))
+		m.RequestSize.Observe(float64(computeApproximateRequestSize(c.Request)))
+		m.ResponseSize.Observe(float64(c.Writer.Size()))
 	}
-}
-
-func (m *Metrics) Register(registry *prometheus.Registry) {
-	registry.MustRegister(
-		m.RequestsInFlight,
-		m.RequestsTotal,
-		m.RequestLatency,
-		m.RequestSize,
-		m.ResponseSize,
-	)
 }
 
 func computeApproximateRequestSize(r *http.Request) int {

--- a/server/proxy/server.go
+++ b/server/proxy/server.go
@@ -68,12 +68,10 @@ func NewServer(
 
 	router.Use(middleware.NewLogger(proxyConfig.AccessLog, logger))
 
-	metrics := middleware.NewMetrics("proxy")
-	if registry != nil {
-		metrics.Register(registry)
+	metrics := middleware.NewMetrics(registry, "proxy")
+	if metrics != nil {
+		router.Use(metrics.Handler())
 	}
-	// endpointID left blank in server proxy
-	router.Use(metrics.Handler(""))
 
 	s.registerRoutes(router)
 

--- a/server/proxy/server.go
+++ b/server/proxy/server.go
@@ -68,8 +68,9 @@ func NewServer(
 
 	router.Use(middleware.NewLogger(proxyConfig.AccessLog, logger))
 
-	metrics := middleware.NewMetrics(registry, "proxy")
-	if metrics != nil {
+	if registry != nil {
+		metrics := middleware.NewMetrics("proxy")
+		metrics.Register(registry)
 		router.Use(metrics.Handler())
 	}
 


### PR DESCRIPTION
After PR #1, agent metrics were ok, byt proxy metrics looked like this:

```
...
piko_proxy_request_latency_seconds_bucket{endpoint="",method="GET",status="503",le="1"} 0
piko_proxy_request_latency_seconds_bucket{endpoint="",method="GET",status="503",le="2.5"} 0
piko_proxy_request_latency_seconds_bucket{endpoint="",method="GET",status="503",le="5"} 1
piko_proxy_request_latency_seconds_bucket{endpoint="",method="GET",status="503",le="10"} 1
piko_proxy_request_latency_seconds_bucket{endpoint="",method="GET",status="503",le="+Inf"} 1
piko_proxy_request_latency_seconds_sum{endpoint="",method="GET",status="503"} 3.025
piko_proxy_request_latency_seconds_count{endpoint="",method="GET",status="503"} 1
# HELP piko_proxy_request_size_bytes Request size
# TYPE piko_proxy_request_size_bytes histogram
piko_proxy_request_size_bytes_bucket{endpoint="",le="256"} 1
piko_proxy_request_size_bytes_bucket{endpoint="",le="1024"} 1
piko_proxy_request_size_bytes_bucket{endpoint="",le="4096"} 1
piko_proxy_request_size_bytes_bucket{endpoint="",le="16384"} 1
piko_proxy_request_size_bytes_bucket{endpoint="",le="65536"} 1
...
```

I expected prometheus metrics to omit empty labels, but they don't. So I'd rather remove the label altogether.

This PR separates the middleware.Metrics object in two flavours: with labels (`LabeledMetrics`) and without (`Metrics`). They share the same metrics, options and Handler, but the `LabeledMetrics` type adds the `endpoint` label.
